### PR TITLE
Add privileged mode to ros-helix in docker compose for usb port access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       dockerfile: Dockerfile
     restart: always
     network_mode: "host"
+    privileged: true
     ipc: host
     pid: host
     environment:


### PR DESCRIPTION
Privileged mode is needed until more fine-grained access permissions are implemented